### PR TITLE
Minor documentation changes

### DIFF
--- a/BareMetal - API.md
+++ b/BareMetal - API.md
@@ -262,7 +262,7 @@ Assembly Example:
 	...
 	Packet: times 1518 db 0
 
-Note: BareMetal does not keep a buffer of received packets. This means that the OS will overwrite the last packet as soon as a new one is received. Continuously polling the network by checking `os_net_rx` often, is possible, but this is not ideal. BareMetal allows for a network interrupt callback handler to be run whenever a packet is received. With a callback, a program will always be aware of when a packet is received. Check `programs/ethtool.asm` for an example of using a callback.
+Note: BareMetal does not keep a buffer of received packets. This means that the OS will overwrite the last packet as soon as a new one is received. Continuously polling the network by checking `os_net_rx` often, is possible, but this is not ideal. BareMetal allows for a network interrupt callback handler to be run whenever a packet is received. With a callback, a program will always be aware of when a packet is received. Check [`programs/ethtool.asm`](https://github.com/ReturnInfinity/BareMetal-OS/blob/master/programs/ethtool.asm) for an example of using a callback.
 
 
 ## Disk

--- a/BareMetal - API.md
+++ b/BareMetal - API.md
@@ -9,36 +9,36 @@ This document details the API calls built into the BareMetal exokernel.
 ### Contents
 
 1. Output
-	- b\_output
-	- b\_output\_chars
+	- os\_output
+	- os\_output\_chars
 2. Input
-	- b\_input
-	- b\_input\_key
+	- os\_input
+	- os\_input\_key
 3. SMP
-	- b\_smp\_enqueue
-	- b\_smp\_dequeue
-	- b\_smp\_run
-	- b\_smp\_wait
+	- os\_smp\_enqueue
+	- os\_smp\_dequeue
+	- os\_smp\_run
+	- os\_smp\_wait
 4. Memory
-	- b\_mem\_allocate
-	- b\_mem\_release
+	- os\_mem\_allocate
+	- os\_mem\_release
 5. Network
-	- b\_net\_tx
-	- b\_net\_rx
+	- os\_net\_tx
+	- os\_net\_rx
 6. Disk
-	- b\_disk\_read
-	- b\_disk\_write
+	- os\_disk\_read
+	- os\_disk\_write
 7. Misc
-	- b\_system\_config
-	- b\_system\_misc
+	- os\_system\_config
+	- os\_system\_misc
 
 
 ## Output
 
 
-### b\_output
+### os\_output
 
-Output text to the screen or via serial. The string must be null-terminated - also known as ASCIIZ.
+Output text to the screen or via serial. The string must be null-terminated (also known as ASCIIZ).
 
 Assembly Registers:
 
@@ -48,19 +48,11 @@ Assembly Registers:
 Assembly Example:
 
 	mov rsi, Message
-	call b_output
+	call os_output
 	...
 	Message: db 'This is a test', 0
 
-C Example:
-
-	char Message[] = "This is a test";
-	b_output(Message);
-	
-	b_output("This is a another test");
-
-
-### b\_output\_chars
+### os\_output\_chars
 
 Output a number of characters to the screen or via serial.
 
@@ -78,18 +70,10 @@ Assembly Example:
 	...
 	Message: db 'This is a test', 0
 
-C Example:
-
-	b_output_chars("This is a test", 4);	// Output 'This'
-	
-	char Message[] = "Hello, world!";
-	b_output_chars(Message, 5);				// Output 'Hello'
-
-
 ## Input
 
 
-### b\_input
+### os\_input
 
 Accept a number of keys from the keyboard or via serial. The resulting string will automatically be null-terminated.
 
@@ -104,17 +88,12 @@ Assembly Example:
 
 	mov rdi, Input
 	mov rcx, 20
-	call b_input
+	call os_input
 	...
 	Input: db 0 times 21
 
-C Example:
 
-	char Input[21];
-	b_input(Input, 20);
-
-
-### b\_input\_key
+### os\_input\_key
 
 Scans for input from keyboard or serial.
 
@@ -126,24 +105,17 @@ Assembly Registers:
 
 Assembly Example:
 
-	call b_input_key
+	call os_input_key
 	mov byte [KeyChar], al
 	...
 	KeyChar: db 0
 
-C Example:
-
-	char KeyChar;
-	KeyChar = b_input_key();
-	if (KeyChar == 'a')
-	...
-
 
 ## SMP
 
-BareMetal uses a queue for tasks. Tasks are automatically pulled out of the queue by available CPU cores.
+BareMetal uses a queue for tasks. Available CPU cores poll the queue for tasks and pull them out automatically.
 
-### b\_smp\_enqueue
+### os\_smp\_enqueue
 
 Add a workload to the processing queue.
 
@@ -157,18 +129,15 @@ Assembly Example:
 
 		mov rax, ap_code	; Our code to run on an available core
 		xor rsi, rsi		; Clear RSI as there is no argument
-		call [b_smp_enqueue]
+		call [os_smp_enqueue]
 		ret
 		
 	ap_code:
 		...
 		ret
 
-C Example:
 
-	
-
-### b\_smp\_dequeue
+### os\_smp\_dequeue
 
 Dequeue a workload from the processing queue.
 
@@ -181,10 +150,7 @@ Assembly Registers:
 Assembly Example:
 
 
-C Example:
-
-
-### b\_smp\_run
+### os\_smp\_run
 
 Call the code address stored in RAX.
 
@@ -196,10 +162,7 @@ Assembly Registers:
 Assembly Example:
 
 
-C Example:
-
-
-### b\_smp\_wait
+### os\_smp\_wait
 
 Wait until all other CPU Cores are finished processing.
 
@@ -211,16 +174,13 @@ Assembly Registers:
 Assembly Example:
 
 
-C Example:
-
-
 ## Memory
 
-Memory is allocated in 2MiB pages.
+Memory in BareMetal is allocated in 2MiB pages.
 
-### b\_mem\_allocate
+### os\_mem\_allocate
 
-Allocate pages of memory
+Allocate a number of 2MiB pages of memory
 
 Assembly Registers:
 
@@ -231,12 +191,12 @@ Assembly Registers:
 Assembly Example:
 
 	mov rcx, 2		; Allocate 2 2MiB pages (4MiB in total)
-	call b_mem_allocate
-	jz mem_fail
-	mov rsi, rax	; Copy memory address to RSI
+	call os_mem_allocate
+	jz mem_fail		; Memory allocation failed
+	mov rsi, rax		; Copy memory address to RSI
 
 
-### b\_mem\_release
+### os\_mem\_release
 
 Release pages of memory
 
@@ -251,13 +211,13 @@ Assembly Example:
 
 	mov rax, rsi	; Copy memory address to RAX
 	mov rcx, 2		; Free 2 2MiB pages (4MiB in total)
-	call b_mem_release
+	call os_mem_release
 
 
 ## Network
 
 
-### b\_net\_tx
+### os\_net\_tx
 
 Transmit data via Ethernet
 
@@ -273,7 +233,7 @@ Assembly Example:
 	mov rsi, Packet
 	mov rcx, 1500
 	mod rdx, 0
-	call b_net_tx
+	call os_net_tx
 	...
 	Packet:
 	Packet_Dest: db 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF ; Broadcast
@@ -281,10 +241,10 @@ Assembly Example:
 	Packet_Type: dw 0xABBA
 	Packet_Data: db 'This is a test', 0
 
-The packet must contain a proper 14-byte header.
+Please note that the packet must contain a proper 14-byte header.
 
 
-### b\_net\_rx
+### os\_net\_rx
 
 Receive data via Ethernet
 
@@ -298,18 +258,18 @@ Assembly Example:
 
 	mov rdi, Packet
 	mov rdx, 0
-	call b_net_rx
+	call os_net_rx
 	...
 	Packet: times 1518 db 0
 
-Notes: BareMetal OS does not keep a buffer of received packets. This means that the OS will overwrite the last packet received as soon as it receives a new one. You can continuously poll the network by checking `b_net_rx` often, but this is not ideal. BareMetal OS allows for a network interrupt callback handler to be run whenever a packet is received. With a callback, your program will always be aware of when a packet was received. Check `programs/ethtool.asm` for an example of using a callback.
+Note: BareMetal does not keep a buffer of received packets. This means that the OS will overwrite the last packet as soon as a new one is received. Continuously polling the network by checking `os_net_rx` often, is possible, but this is not ideal. BareMetal allows for a network interrupt callback handler to be run whenever a packet is received. With a callback, a program will always be aware of when a packet is received. Check `programs/ethtool.asm` for an example of using a callback.
 
 
 ## Disk
 
 BareMetal uses 4096 byte sectors for all disk access. Disk sectors start at 0. Individual calls to disk read and write functions support up to 512 sectors being read/written (2MiB).
 
-### b\_disk\_read
+### os\_disk\_read
 
 Read a number of sectors from disk to memory
 
@@ -328,10 +288,10 @@ Assembly Example:
 	mov rcx, 1		; Read one sector
 	mov rdx, 0		; Read from Disk 0
 	mov rdi, diskbuffer	; Read disk to this memory address
-	call b_disk_read
+	call os_disk_read
 
 
-### b\_disk\_write
+### os\_disk\_write
 
 Write a number of sectors from memory to disk
 
@@ -350,13 +310,11 @@ Assembly Example:
 	mov rcx, 1		; Write one sector
 	mov rdx, 0		; Write to Disk 0
 	mov rsi, diskbuffer	; Write the contents from this memory address to disk
-	call b_disk_write
-
+	call os_disk_write
 
 ## Misc
 
-
-### b\_system\_config
+### os\_system\_config
 
 View or modify system configuration options
 
@@ -366,7 +324,7 @@ Assembly Registers:
 			RAX = Variable 1
 	OUT:	RAX = Result 1
 
-Function numbers come in pairs (one for reading a parameter, and one for writing a parameter). `b_system_config` should be called with a function alias and not a direct function number.
+Function numbers come in pairs (one for reading a parameter, and one for writing a parameter). `os_system_config` should be called with a function alias and not a direct function number.
 
 Currently the following functions are supported:
 
@@ -399,7 +357,7 @@ every function that gets something sets RAX with the result
 
 every function that sets something gets the value from RAX
 
-### b\_system\_misc
+### os\_system\_misc
 
 Call miscellaneous OS sub-functions
 


### PR DESCRIPTION
`b_` has been changed to `os_` based on #6.
C examples were also removed as Newlib is part of BareMetal OS, and not the kernel.
Some other minor changes were made as well.