### PR TITLE
Added BMFS to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,10 @@
 *.bin
 *.asm~
 *.md~
+bmfs.image
+Alloy
+BMFS
 Pure64
+bin
+include
+lib

--- a/build_x86-64.sh
+++ b/build_x86-64.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export topdir=$(pwd)
+
 cd Pure64/
 ./build.sh
 cp multiboot.sys ../
@@ -9,6 +11,12 @@ cd ..
 cd src/x86-64/
 nasm kernel.asm -o ../../kernel.sys
 cd ../..
+
+cd BMFS/
+MAKEFLAGS="NO_FUSE=1 NO_UNIX_UTILS=1"
+make $MAKEFLAGS
+make $MAKEFLAGS install PREFIX=$topdir
+cd ..
 
 cd Alloy/
 ./build.sh

--- a/setup.sh
+++ b/setup.sh
@@ -2,3 +2,4 @@
 
 git clone https://github.com/ReturnInfinity/Pure64.git
 git clone https://github.com/ReturnInfinity/Alloy.git
+git clone https://github.com/ReturnInfinity/BMFS.git


### PR DESCRIPTION
BMFS is required for Alloy, so that the file system code is not duplicated.