### PR TITLE
Producing ELF File with Debugging Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+*.o
+*.elf
 *.sys
 *.bin
 *.asm~

--- a/build_x86-64.sh
+++ b/build_x86-64.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd src/x86-64/
-nasm kernel.asm -o ../../kernel.sys -l ../../kernel-debug.txt
+./build.sh
 cd ../..

--- a/src/x86-64/build.sh
+++ b/src/x86-64/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+nasm kernel.asm -o kernel.o -f elf64 -g -F dwarf
+ld kernel.o -o kernel.elf -T kernel.ld
+objcopy -O binary kernel.elf kernel.bin

--- a/src/x86-64/kernel.asm
+++ b/src/x86-64/kernel.asm
@@ -7,7 +7,6 @@
 
 
 BITS 64					; Specify 64-bit for flat binary
-ORG 0x0000000000100000			; Kernel location is at 1 MiB
 
 %DEFINE BAREMETAL_VER 'v1.0.0 (November 13, 2016)', 13, 'Copyright (C) 2008-2017 Return Infinity', 13, 0
 %DEFINE BAREMETAL_API_VER 1

--- a/src/x86-64/kernel.ld
+++ b/src/x86-64/kernel.ld
@@ -1,0 +1,4 @@
+SECTIONS {
+	. = 0x100000;
+	.text : { *(.text) }
+}


### PR DESCRIPTION
The build script now generates:

```
src/x86-64/kernel.o
src/x86-64/kernel.elf
src/x86-64/kernel.bin
```

With the last two files being the important ones.

The debugging information only goes into the ELF file, the binary only contains executable code.

This requires that users have `ld` and `objcopy` (or in other words, the `binutils` package) installed on their system.