### PR TITLE
Updated Payload Address

### DIFF
--- a/src/x86-64/kernel.asm
+++ b/src/x86-64/kernel.asm
@@ -117,7 +117,7 @@ ap_process:
 init_process:
 	call b_smp_get_id		; Get the ID of the current core
 	mov rcx, rax
-	mov rax, 0x200000		; Payload was copied here
+	mov rax, 0x1E0000		; Payload was copied here
 	call b_smp_set
 	mov qword [os_ClockCallback], 0	; Clear the callback
 	ret


### PR DESCRIPTION
There was a section of code that still pointed to the Alloy address.

I found it because gdb and QEMU showed me that the loader wasn't getting called.

I verified that updating this address fixed the problem.
