### PR TITLE
Added Makefile build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+TARGET_ARCHITECTURE ?= x86-64
+
+.PHONY: all clean test install
+all clean test install:
+	$(MAKE) -C src/$(TARGET_ARCHITECTURE) $@
+
+$(V).SILENT:

--- a/src/x86-64/Makefile
+++ b/src/x86-64/Makefile
@@ -1,0 +1,70 @@
+NASM ?= nasm
+
+LD := $(CROSS_COMPILE)ld
+
+OBJCOPY := $(CROSS_COMPILE)objcopy
+
+kernelfiles += kernel.asm
+kernelfiles += init.asm
+kernelfiles += init/64.asm
+kernelfiles += init/hdd.asm
+kernelfiles += init/net.asm
+kernelfiles += init/pci.asm
+kernelfiles += syscalls.asm
+kernelfiles += syscalls/disk.asm
+kernelfiles += syscalls/input.asm
+kernelfiles += syscalls/memory.asm
+kernelfiles += syscalls/misc.asm
+kernelfiles += syscalls/net.asm
+kernelfiles += syscalls/screen.asm
+kernelfiles += syscalls/smp.asm
+kernelfiles += drivers.asm
+kernelfiles += drivers/pci.asm
+kernelfiles += drivers/pic.asm
+kernelfiles += drivers/storage/ahci.asm
+kernelfiles += drivers/net/i8254x.asm
+kernelfiles += drivers/net/rtl8169.asm
+kernelfiles += drivers/net/virtio.asm
+kernelfiles += interrupt.asm
+kernelfiles += sysvar.asm
+
+installfiles += kernel.sys kernel-debug.txt
+installfiles += kernel.bin kernel.elf
+installfiles := $(installfiles:%=$(DESTDIR)$(PREFIX)/system/%)
+
+.PHONY: all
+all: kernel.sys kernel-debug.txt kernel.elf kernel.bin
+
+kernel.sys kernel-debug.txt: $(kernelfiles) nasm.ld
+	@echo "NASM $@"
+	$(NASM) -P nasm.ld kernel.asm -o $@ -l kernel-debug.txt
+
+kernel.bin: kernel.elf
+	@echo "OBJCOPY $@"
+	$(OBJCOPY) -O binary $< $@
+
+kernel.elf: kernel.o kernel.ld
+	@echo "LINK $@"
+	$(LD) -T kernel.ld $< -o $@
+
+kernel.o: $(kernelfiles)
+	@echo "NASM $@"
+	$(NASM) -f elf64 -g -F dwarf kernel.asm -o $@
+
+.PHONY: clean
+clean:
+	$(RM) kernel.sys kernel-debug.txt kernel.bin kernel.elf kernel.o
+
+.PHONY: test
+test:
+
+.PHONY: install
+install: $(DESTDIR)$(PREFIX)/system $(installfiles)
+
+$(DESTDIR)$(PREFIX)/system:
+	mkdir -p $@
+
+$(DESTDIR)$(PREFIX)/system/%: %
+	cp $< $@
+
+$(V).SILENT:


### PR DESCRIPTION
Like Pure64, this PR is intended to help complete the feature branch on BareMetal-OS for supporting the Makefile build system.

This Makefile builds and installs the following files:

 - kernel.sys
 - kernel-debug.txt
 - kernel.bin
 - kernel.elf

To `output/system` in the BareMetal-OS project.