### PR TITLE
Overwrite Kernel Output Syscall

### DIFF
--- a/api/libBareMetal.asm
+++ b/api/libBareMetal.asm
@@ -31,7 +31,11 @@ networkcallback_get	equ 3
 networkcallback_set	equ 4
 clockcallback_get	equ 5
 clockcallback_set	equ 6
-
+mac			equ 30
+pci_read		equ 0x40
+pci_write		equ 0x41
+stdout_set		equ 0x42
+stdout_get		equ 0x43
 
 ; Index for b_system_misc calls
 smp_get_id		equ 1

--- a/api/libBareMetal.h
+++ b/api/libBareMetal.h
@@ -39,6 +39,10 @@ void b_system_misc(unsigned long function, void *var1, void *var2);
 #define CLOCKCALLBACK_GET    5
 #define CLOCKCALLBACK_SET    6
 #define MAC                  30
+#define PCI_READ             0x40
+#define PCI_WRITE            0x41
+#define STDOUT_SET           0x42
+#define STDOUT_GET           0x43
 
 // Index for b_system_misc calls
 #define SMP_GET_ID       1

--- a/src/x86-64/syscalls/config.asm
+++ b/src/x86-64/syscalls/config.asm
@@ -31,6 +31,11 @@ b_system_config:
 	je b_system_config_pci_read
 	cmp rcx, 0x41
 	je b_system_config_pci_write
+	; Standard Output
+	cmp rcx, 0x42
+	je b_system_config_stdout_set
+	cmp rcx, 0x43
+	je b_system_config_stdout_get
 	ret
 
 b_system_config_timecounter:
@@ -64,6 +69,15 @@ b_system_config_pci_read:
 b_system_config_pci_write:
 	call os_pci_write
 	ret
+
+b_system_config_stdout_get:
+	mov rax, qword [0x100018]
+	ret
+
+b_system_config_stdout_set:
+	mov qword [0x100018], rax
+	ret
+
 ; -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This pull request allows the kernel output function to be overwritten.

It's kind of tricky to use though, since the output function expects the message location in RSI and the message length in RCX. GCC puts the first two parameters of a function in RDI and then RSI (according to the System V ABI.) Fixing this will require patching the `libBareMetal.c` assembly and working some magic there. It will probably end up requiring a separate assembly implementation, perhaps `libBareMetal.S`, for this wrapper function to live in.

I've also updated some other system config calls in the C API and assembly API in this pull request.

This should help in closing #36.